### PR TITLE
Httpclient update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 		    <groupId>org.apache.httpcomponents</groupId>
 		    <artifactId>httpclient</artifactId>
-		    <version>4.3.6</version>
+		    <version>4.5.3</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
To be able to use aws-stepfunctions a newer version of org.apache.http.components.httpclient is required, minimum working version is 4.5.2